### PR TITLE
updating version of Wireshark and adding note for Ubuntu users

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ you want or need to.
 Plugin binaries
 ---------------
 
+NOTE: Users of a recent Ubuntu release (such as 19.04) can skip this section 
+and have to proceed to build from source, as the Ubuntu package repositories do 
+no longer provide Wireshark-gtk in version 2.4 but only 2.6. 
+Below build process was tested on Ubuntu 19.04 though and works. 
+
 First a note of caution, this plugin only works with Wireshark-gtk (or
 Wireshark-legacy in some distribution) version 2.4.X. So you first
 need to be sure to have the right version of Wireshark installed on

--- a/prepare-wireshark-canvas-sources.sh
+++ b/prepare-wireshark-canvas-sources.sh
@@ -1,14 +1,15 @@
 #!/bin/sh
 set -e
 
-wget --continue https://www.wireshark.org/download/src/wireshark-2.4.14.tar.xz
-tar xf wireshark-2.4.14.tar.xz
+wget --continue https://www.wireshark.org/download/src/wireshark-2.4.15.tar.xz
+tar xf wireshark-2.4.15.tar.xz
 wget --continue https://canlogger.csselectronics.com/files/wiresharkplugin/WS_v2.4-Plugin_v7.1.zip
 unzip -o -q WS_v2.4-Plugin_v7.1.zip
-mkdir -p wireshark-2.4.14/plugins/canvas
-mv WS_v2.4-Plugin_v7.1/CANvas-Wireshark-v2.4-Plugin-CSS-Electronics_v7.1/Source/* wireshark-2.4.14/plugins/canvas/
-rm -f wireshark-2.4.14.tar.xz
+mkdir -p wireshark-2.4.15/plugins/canvas
+mv WS_v2.4-Plugin_v7.1/WS_v2.4-Plugin_v7.1/CANvas-Wireshark-v2.4-Plugin-CSS-Electronics_v7.1/Source/* wireshark-2.4.15/plugins/canvas/
+rm -f wireshark-2.4.15.tar.xz
 rm -f WS_v2.4-Plugin_v7.1.zip
 rm -rf WS_v2.4-Plugin_v7.1/
-cd wireshark-2.4.14/ && patch -p1 -i ../add-canvas-plugin.patch
+cd wireshark-2.4.15/ && patch -p1 -i ../add-canvas-plugin.patch
 echo "Wireshark and CANvas sources are ready, you can now build them."
+


### PR DESCRIPTION
This pull request fixes a broken link to Wireshark 2.4.14 by replacing it with 2.4.15 (also in subsequent commands). The documented build process was tested on Ubuntu 19.04 and works as described (with the fix applied). The request also adds a note into the readme to tell Ubuntu users that wireshark-gtk is no longer available in version 2.4.x in their APT-repos, thus they have to proceed with building from source. 

BTW: Thanks a lot for this repo, it was extremely helpful. Good work!